### PR TITLE
Update install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,7 +19,7 @@ chmod 0755 kubectl
 sudo mv kubectl /usr/local/bin
 
 echo "Install the Bluemix container-service plugin"
-bx plugin install container-service -r Bluemix
+bx plugin install container-service -r Bluemix -f
 
 if [[ -n "$DEBUG" ]]; then
   bx --version


### PR DESCRIPTION
If the container-service plugin is already installed. The command "bx plugin install container-service -r Bluemix" asks for 
"Plug-in 'container-service 0.1.397' was already installed. Do you want to update it with 'container-service 0.1.401' or not? (yes/no)> yes". This causes the deploy to fail. Changing the command to "bx plugin install container-service -r Bluemix -f", by forcing the install solves this issue.